### PR TITLE
[REF] requirements.txt: Remove numpy installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-altair
+# commented since that it is installing numpy :(
+# altair
 py3o.template
 py3o.formats


### PR DESCRIPTION
altair depends of numpy
numpy raise weird errors:
    - https://github.com/Vauxoo/maintainer-quality-tools/pull/315
    - https://github.com/numpy/numpy/issues/17674
    - https://github.com/numpy/numpy/issues/13059