### PR TITLE
[FIX] report_qweb_encrypt: accept a single res_id, like _render_qweb_pdf does

### DIFF
--- a/report_qweb_encrypt/models/ir_actions_report.py
+++ b/report_qweb_encrypt/models/ir_actions_report.py
@@ -33,6 +33,12 @@ class IrActionsReport(models.Model):
         )
         report_sudo = self._get_report(report_ref)
         if res_ids:
+            # `_render_qweb_pdf` also accepts a single id, and several callers use
+            # that form (`stock.stock_picking`, `hr_payroll.hr_payslip`,
+            # `account_followup.res_partner`...). Slicing an int raises TypeError
+            # before the password is ever read.
+            if isinstance(res_ids, int):
+                res_ids = [res_ids]
             encrypt_password = self.env.context.get("encrypt_password")
             report = self._get_report_from_name(report_sudo.report_name).with_context(
                 encrypt_password=encrypt_password

--- a/report_qweb_encrypt/tests/test_report_qweb_encrypt.py
+++ b/report_qweb_encrypt/tests/test_report_qweb_encrypt.py
@@ -48,4 +48,12 @@ class TestReportQwebEncrypt(HttpCase):
         pdf, _ = report.with_context(**ctx)._render_qweb_pdf(report.report_name, [1])
         self.assertTrue(pdf.count(b"/Encrypt"))
 
+    def test_report_qweb_encrypt_single_res_id(self):
+        """`res_ids` may be a single id instead of a list."""
+        ctx = {"force_report_rendering": True, "encrypt_password": "secretcode"}
+        report = self.env.ref("web.action_report_internalpreview")
+        report.encrypt = "manual"
+        pdf, _ = report.with_context(**ctx)._render_qweb_pdf(report.report_name, 1)
+        self.assertTrue(pdf.count(b"/Encrypt"))
+
     # TODO: test_report_qweb_manual_encrypt, require JS test?


### PR DESCRIPTION
@moylop260 — para cuando puedas mergearlo. Sale del trabajo de migración de IRC (Islamic Relief Canada); no bloquea nuestra corrida, pero el defecto es de upstream y no de nosotros, así que va aquí.

## El defecto

`_render_qweb_pdf(report_ref, res_ids=None, data=None)` acepta una lista de ids **o un id suelto**. El override de este módulo hace `res_ids[:1]` para elegir el registro cuyo password aplica, así que un int revienta con

```
TypeError: 'int' object is not subscriptable
```

antes de leer el password. El reporte deja de renderizar para cualquier caller que pase un solo id, con el módulo instalado y un password que aplique.

## Quién pasa un id suelto

Búsqueda sobre todos los `.py` de `odoo/addons`, `odoo/odoo` y `enterprise` en 19.0:

| tree | call site |
|---|---|
| odoo | `addons/stock/models/stock_picking.py:2014` |
| odoo | `addons/l10n_ar_stock/models/stock_picking.py:78` |
| enterprise | `hr_payroll/models/hr_payslip.py:559` |
| enterprise | `hr_payroll/controllers/main.py:35` |
| enterprise | `account_followup/models/res_partner.py:685` |
| enterprise | `whatsapp/models/whatsapp_template.py:877` |
| enterprise | `l10n_ec_edi_stock/models/stock_picking.py:270` |

Más siete tests de `account` y `base` que llaman con `res_ids=<int>`.

**No busqué** en otros repos de OCA ni fuera de esos tres árboles, así que puede haber más.

## Por qué la suite no lo vio

Los tres tests existentes pasan `[1]`. El test nuevo usa la forma int, y falla sin el fix.

## Lo que no verifiqué

**No corrí la suite localmente** — no tengo una base con `report_qweb_encrypt` instalado a la mano y no quise levantar una para dos líneas. El razonamiento del crash es de lectura del código, no de una traza. La CI de acá es el veredicto.

`pre-commit-vauxoo` corre limpio sobre los dos archivos tocados; los fallos mandatory que reporta el repo son deuda preexistente de `base_comment_template`, `report_py3o`, `report_csv` y otros, ninguno de este módulo.